### PR TITLE
Remove useless `rb_gc_register_mark_object` calls

### DIFF
--- a/ext/xrb/escape.c
+++ b/ext/xrb/escape.c
@@ -159,8 +159,6 @@ VALUE XRB_Markup_escape_string(VALUE self, VALUE string) {
 
 void Init_XRB_escape(void) {
 	rb_XRB_MarkupString = rb_define_class_under(rb_XRB, "MarkupString", rb_cString);
-	rb_gc_register_mark_object(rb_XRB_MarkupString);
-	
 	rb_include_module(rb_XRB_MarkupString, rb_XRB_Markup);
 	
 	rb_undef_method(rb_class_of(rb_XRB_Markup), "escape_string");

--- a/ext/xrb/xrb.c
+++ b/ext/xrb/xrb.c
@@ -50,13 +50,8 @@ void Init_XRB_Extension(void) {
 	id_concat = rb_intern("<<");
 	
 	rb_XRB = rb_define_module("XRB");
-	rb_gc_register_mark_object(rb_XRB);
-	
 	rb_XRB_Markup = rb_define_module_under(rb_XRB, "Markup");
-	rb_gc_register_mark_object(rb_XRB_Markup);
-	
 	rb_XRB_Native = rb_define_module_under(rb_XRB, "Native");
-	rb_gc_register_mark_object(rb_XRB_Native);
 	
 	Init_XRB_escape();
 	


### PR DESCRIPTION
The `rb_define_*` familly of function already register the returned class or module as a "root" object, meaning it can't be GCed nor moved.

Hence calling `rb_gc_register_mark_object` on these is useless.

It's only useful for objects that are only defined in Ruby.
