### PR TITLE
Add support for `html_safe?` predicate.

### DIFF
--- a/lib/xrb/markup.rb
+++ b/lib/xrb/markup.rb
@@ -46,6 +46,12 @@ module XRB
 		def self.raw(string)
 			self.new(string, false)
 		end
+		
+		# This "string" is already escaped, thus it is safe to append to the output buffer.
+		# This predicate is used by Rails' `ActionView::OutputBuffer` to determine if the string should be escaped or not.
+		def html_safe?
+			true
+		end
 	end
 	
 	module Script

--- a/test/xrb/builder.rb
+++ b/test/xrb/builder.rb
@@ -163,4 +163,17 @@ describe XRB::Builder do
 			XML
 		end
 	end
+	
+	with '#to_s' do
+		it "generates html safe string" do
+			# This test is specifically for Rails compatibility.
+			fragment = XRB::Builder.fragment do |builder|
+				builder.tag('div') do
+					builder.text('Hello World')
+				end
+			end
+			
+			expect(fragment.to_s).to be(:html_safe?)
+		end
+	end
 end

--- a/test/xrb/markup_string.rb
+++ b/test/xrb/markup_string.rb
@@ -61,4 +61,10 @@ describe XRB::MarkupString do
 			expect(XRB::MarkupString.new("<h1>Hello World</h1>", false)).to be == "<h1>Hello World</h1>"
 		end
 	end
+	
+	with '#html_safe?' do
+		it 'can be used to safely append to an output buffer' do
+			expect(XRB::MarkupString.new.html_safe?).to be_truthy
+		end
+	end
 end


### PR DESCRIPTION
Better compatibility with Rails. Mark fragments and MarkupStrings as HTML safe.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
