### PR TITLE
Fix segfault on invalid attributes.

### DIFF
--- a/ext/xrb/tag.c
+++ b/ext/xrb/tag.c
@@ -97,13 +97,18 @@ VALUE XRB_Tag_append_attributes(VALUE self, VALUE buffer, VALUE attributes, VALU
 		
 		for (i = 0; i < RARRAY_LEN(attributes); i++) {
 			VALUE attribute = RARRAY_AREF(attributes, i);
+			
+			if (rb_type(attribute) != T_ARRAY || RARRAY_LEN(attribute) != 2) {
+				rb_raise(rb_eTypeError, "expected array for attribute key/value pair");
+			}
+			
 			VALUE key = RARRAY_AREF(attribute, 0);
 			VALUE value = RARRAY_AREF(attribute, 1);
 			
 			XRB_Tag_append_tag_attribute(buffer, key, value, prefix);
 		}
 	} else {
-		rb_raise(rb_eArgError, "expected hash or array for attributes");
+		rb_raise(rb_eTypeError, "expected hash or array for attributes");
 	}
 	
 	return Qnil;

--- a/lib/xrb/tag.rb
+++ b/lib/xrb/tag.rb
@@ -99,7 +99,11 @@ module XRB
 				when Hash
 					self.append_attributes(buffer, value, attribute_key)
 				when Array
-					self.append_attributes(buffer, value, attribute_key)
+					value.each do |attribute|
+						raise TypeError, "expected array of key-value pairs" unless attribute.is_a?(Array) and attribute.size == 2
+						
+						self.append_attributes(buffer, [attribute], attribute_key)
+					end
 				when TrueClass
 					buffer << ' ' << attribute_key.to_s
 				else

--- a/test/xrb/builder.rb
+++ b/test/xrb/builder.rb
@@ -94,6 +94,12 @@ describe XRB::Builder do
 			builder.tag :t, [[:a, 10], [:b, nil]]
 			expect(builder.output).to be == %Q{<t a="10"/>}
 		end
+		
+		it "should raise type error for invalid attributes" do
+			expect do
+				builder.tag :t, {a: [1, 2, 3, 4, 5]}
+			end.to raise_exception(TypeError)
+		end
 	end
 	
 	with '#inline' do


### PR DESCRIPTION
```
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:202: [BUG] Segmentation fault at 0x000000000000040d
ruby 3.3.1 (2024-04-23 revision c56cd86388) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0015 p:---- s:0081 e:000080 CFUNC  :write_opening_tag
c:0014 p:0055 s:0076 e:000075 METHOD /home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:202
c:0013 p:0021 s:0065 e:000064 METHOD /home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:118
c:0012 p:0015 s:0058 e:000057 BLOCK  /home/samuel/.gem/ruby/3.3.1/gems/live-0.8.0/lib/live/view.rb:56
c:0011 p:0007 s:0054 e:000053 METHOD /home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:23
c:0010 p:0018 s:0049 e:000048 METHOD /home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:30 [FINISH]
c:0009 p:---- s:0045 e:000044 CFUNC  :to_json
c:0008 p:0017 s:0040 e:000039 METHOD /home/samuel/.gem/ruby/3.3.1/gems/activesupport-7.1.3.2/lib/active_support/core_ext/object/json.rb:39 [FINISH]
c:0007 p:---- s:0035 e:000034 CFUNC  :generate
c:0006 p:0031 s:0030 e:000029 METHOD /home/samuel/.gem/ruby/3.3.1/gems/json-2.7.2/lib/json/common.rb:306
c:0005 p:0007 s:0023 e:000021 METHOD /home/samuel/.gem/ruby/3.3.1/gems/protocol-websocket-0.12.1/lib/protocol/websocket/json_message.rb:20
c:0004 p:0025 s:0017 e:000015 BLOCK  /home/samuel/.gem/ruby/3.3.1/gems/live-0.8.0/lib/live/page.rb:98
c:0003 p:0010 s:0012 e:000011 BLOCK  /home/samuel/.gem/ruby/3.3.1/gems/async-2.11.0/lib/async/task.rb:164
c:0002 p:0008 s:0009 e:000007 BLOCK  /home/samuel/.gem/ruby/3.3.1/gems/async-2.11.0/lib/async/task.rb:377 [FINISH]
c:0001 p:---- s:0003 e:000002 DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
/home/samuel/.gem/ruby/3.3.1/gems/async-2.11.0/lib/async/task.rb:377:in `block in schedule'
/home/samuel/.gem/ruby/3.3.1/gems/async-2.11.0/lib/async/task.rb:164:in `block in run'
/home/samuel/.gem/ruby/3.3.1/gems/live-0.8.0/lib/live/page.rb:98:in `block in run'
/home/samuel/.gem/ruby/3.3.1/gems/protocol-websocket-0.12.1/lib/protocol/websocket/json_message.rb:20:in `generate'
/home/samuel/.gem/ruby/3.3.1/gems/json-2.7.2/lib/json/common.rb:306:in `generate'
/home/samuel/.gem/ruby/3.3.1/gems/json-2.7.2/lib/json/common.rb:306:in `generate'
/home/samuel/.gem/ruby/3.3.1/gems/activesupport-7.1.3.2/lib/active_support/core_ext/object/json.rb:39:in `to_json'
/home/samuel/.gem/ruby/3.3.1/gems/activesupport-7.1.3.2/lib/active_support/core_ext/object/json.rb:39:in `to_json'
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:30:in `to_s'
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:23:in `call'
/home/samuel/.gem/ruby/3.3.1/gems/live-0.8.0/lib/live/view.rb:56:in `block in to_html'
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:118:in `tag'
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:202:in `full_tag'
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/xrb/builder.rb:202:in `write_opening_tag'

-- Threading information ---------------------------------------------------
Total ractor count: 1
Ruby thread count for this ractor: 2

-- Machine register context ------------------------------------------------
 RIP: 0x00007be1d7f19dc6 RBP: 0x00000000008c110c RSP: 0x00007be1d64eebc0
 RAX: 0x000000000000040d RBX: 0x0000000000000000 RCX: 0x0000000000000007
 RDX: 0x000000000000041d RDI: 0x0000000000000004 RSI: 0x00007be1d5f2a0e8
  R8: 0x00000000000000a8  R9: 0x00007be1d5f29fa8 R10: 0x0000000000000001
 R11: 0x0000000000000000 R12: 0x00007be1d5f29fa8 R13: 0x00007be1d5f2a0e8
 R14: 0x00007be1d47f1ea8 R15: 0x00000000008c110c EFL: 0x0000000000010206

-- C level backtrace information -------------------------------------------
/home/samuel/.rubies/ruby-3.3.1/bin/ruby(rb_print_backtrace+0x14) [0x56cd309898f3] /home/samuel/src/ruby-3.3.1/vm_dump.c:820
/home/samuel/.rubies/ruby-3.3.1/bin/ruby(rb_vm_bugreport) /home/samuel/src/ruby-3.3.1/vm_dump.c:1151
/home/samuel/.rubies/ruby-3.3.1/bin/ruby(rb_bug_for_fatal_signal+0xf8) [0x56cd30b46878] /home/samuel/src/ruby-3.3.1/error.c:1065
/home/samuel/.rubies/ruby-3.3.1/bin/ruby(sigsegv+0x4b) [0x56cd308d24eb] /home/samuel/src/ruby-3.3.1/signal.c:926
/usr/lib/libc.so.6(0x7be1f18d9e20) [0x7be1f18d9e20]
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/XRB_Extension.so(rb_array_const_ptr+0x8) [0x7be1d7f19dc6] /home/samuel/.rubies/ruby-3.3.1/include/ruby-3.3.0/ruby/internal/core/rarray.h:302
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/XRB_Extension.so(XRB_Tag_append_attributes) ./xrb/tag.c:100
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/XRB_Extension.so(XRB_Tag_append_attributes) ./xrb/tag.c:89
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/XRB_Extension.so(XRB_Tag_append_attributes) (null):0
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/XRB_Extension.so(XRB_Tag_append_tag_attribute+0xd1) [0x7be1d7f1a5bc] ./xrb/tag.c:63
/home/samuel/.gem/ruby/3.3.1/gems/xrb-0.6.0/lib/XRB_Extension.so(XRB_Tag_append_tag_attribute_foreach) ./xrb/tag.c:84
```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
