### PR TITLE
Improve flexibility of how appending a value to an output buffer works.

### DIFF
--- a/ext/xrb/escape.h
+++ b/ext/xrb/escape.h
@@ -9,7 +9,7 @@ void Init_XRB_escape(void);
 VALUE XRB_MarkupString_raw(VALUE self, VALUE string);
 
 // Append any value to the output buffer efficiently, escaping entities as needed.
-VALUE XRB_Markup_append(VALUE self, VALUE buffer, VALUE value);
+VALUE XRB_Markup_append_markup(VALUE self, VALUE buffer);
 
 // Escape any entities in the given string. If no entities were found, might return the original string.
 VALUE XRB_Markup_escape_string(VALUE self, VALUE string);

--- a/ext/xrb/tag.c
+++ b/ext/xrb/tag.c
@@ -67,7 +67,7 @@ static void XRB_Tag_append_tag_attribute(VALUE buffer, VALUE key, VALUE value, V
 		
 		if (value != Qtrue) {
 			rb_str_cat_cstr(buffer, "=\"");
-			XRB_Markup_append(Qnil, buffer, value);
+			XRB_Markup_append_markup(value, buffer);
 			rb_str_cat_cstr(buffer, "\"");
 		}
 	}
@@ -160,7 +160,7 @@ VALUE XRB_Tag_append_tag_string(VALUE self, VALUE buffer, VALUE name, VALUE attr
 		rb_str_cat_cstr(buffer, ">");
 		
 		if (content != Qtrue) {
-			XRB_Markup_append(self, buffer, content);
+			XRB_Markup_append_markup(content, buffer);
 		}
 		
 		rb_str_cat_cstr(buffer, "</");

--- a/ext/xrb/xrb.c
+++ b/ext/xrb/xrb.c
@@ -51,6 +51,7 @@ void Init_XRB_Extension(void) {
 	
 	rb_XRB = rb_define_module("XRB");
 	rb_XRB_Markup = rb_define_module_under(rb_XRB, "Markup");
+	rb_XRB_MarkupString = rb_define_class_under(rb_XRB, "MarkupString", rb_cString);
 	rb_XRB_Native = rb_define_module_under(rb_XRB, "Native");
 	
 	Init_XRB_escape();

--- a/lib/xrb/builder.rb
+++ b/lib/xrb/builder.rb
@@ -19,18 +19,17 @@ module XRB
 				@builder = nil
 			end
 			
-			def call(builder)
+			def to_markup(builder)
 				@block.call(builder)
 			end
 			
+
 			def to_s
-				unless @builder
-					@builder = Builder.new
-					
-					self.call(@builder)
-				end
+				builder = Builder.new
 				
-				return @builder.to_s
+				self.to_markup(builder)
+				
+				return builder.to_s
 			end
 			
 			def == other
@@ -161,15 +160,7 @@ module XRB
 		end
 		
 		def <<(content)
-			return unless content
-			
-			if content.is_a?(Fragment)
-				inline! do
-					content.call(self)
-				end
-			else
-				Markup.append(@output, content)
-			end
+			content&.to_markup(self)
 		end
 		
 		# Append pre-existing markup:

--- a/lib/xrb/builder.rb
+++ b/lib/xrb/builder.rb
@@ -9,8 +9,6 @@ require_relative 'tag'
 module XRB
 	# Build markup quickly and efficiently.
 	class Builder
-		include Markup
-		
 		INDENT = "\t"
 		
 		class Fragment
@@ -19,17 +17,20 @@ module XRB
 				@builder = nil
 			end
 			
-			def to_markup(builder)
+			def append_markup(output)
+				builder = Builder.new(output)
+				
+				self.build_markup(builder)
+				
+				return builder.output
+			end
+			
+			def build_markup(builder)
 				@block.call(builder)
 			end
 			
-
 			def to_s
-				builder = Builder.new
-				
-				self.to_markup(builder)
-				
-				return builder.to_s
+				self.append_markup(nil)
 			end
 			
 			def == other
@@ -81,6 +82,10 @@ module XRB
 			
 			@level = [0]
 			@children = [0]
+		end
+		
+		def build_markup(builder)
+			builder.append(@output)
 		end
 		
 		attr :output
@@ -148,7 +153,7 @@ module XRB
 				@output << indentation
 			end
 			
-			Markup.append(@output, content)
+			content.build_markup(self)
 			
 			if @indent
 				@output << "\n"
@@ -160,7 +165,7 @@ module XRB
 		end
 		
 		def <<(content)
-			content&.to_markup(self)
+			content&.build_markup(self)
 		end
 		
 		# Append pre-existing markup:

--- a/lib/xrb/markup.rb
+++ b/lib/xrb/markup.rb
@@ -61,4 +61,12 @@ module XRB
 			MarkupString.new(JSON.dump(value), false)
 		end
 	end
+	
+	module ToMarkup
+		def to_markup(builder)
+			::XRB::Markup.append(builder.output, self.to_s)
+		end
+	end
+	
+	::Object.prepend(ToMarkup)
 end

--- a/lib/xrb/markup.rb
+++ b/lib/xrb/markup.rb
@@ -12,6 +12,10 @@ module XRB
 			MarkupString.raw(string)
 		end
 		
+		def self.append(output, value)
+			value.append_markup(output)
+		end
+		
 		def append_markup(output)
 			output << ::CGI.escape_html(self.to_s)
 		end

--- a/lib/xrb/tag.rb
+++ b/lib/xrb/tag.rb
@@ -8,8 +8,6 @@ require_relative 'markup'
 module XRB
 	# This represents an individual SGML tag, e.g. <a>, </a> or <a />, with attributes. Attribute values must be escaped.
 	Tag = Struct.new(:name, :closed, :attributes) do
-		include XRB::Markup
-		
 		def self.split(qualified_name)
 			if i = qualified_name.index(':')
 				return qualified_name.slice(0...i), qualified_name.slice(i+1..-1)
@@ -80,7 +78,7 @@ module XRB
 			else
 				buffer << '>'
 				unless content == true
-					Markup.append(buffer, content)
+					content.append_markup(buffer)
 				end
 				buffer << '</' << name.to_s << '>'
 			end
@@ -108,7 +106,7 @@ module XRB
 					buffer << ' ' << attribute_key.to_s
 				else
 					buffer << ' ' << attribute_key.to_s << '="'
-					Markup.append(buffer, value)
+					value.append_markup(buffer)
 					buffer << '"'
 				end
 			end

--- a/test/xrb/.template/element.xml
+++ b/test/xrb/.template/element.xml
@@ -1,0 +1,1 @@
+<div><p>Hello <strong>World</strong></p></div>

--- a/test/xrb/.template/element.xrb
+++ b/test/xrb/.template/element.xrb
@@ -1,18 +1,12 @@
 <?r
 class MyElement
-	def to_html
-		XRB::Builder.fragment do |builder|
-			builder.inline(:div) do
-				builder.inline(:p) do
-					builder.text("Hello ")
-					builder.inline(:strong) { builder.text("World") }
-				end
+	def build_markup(builder)
+		builder.inline(:div) do
+			builder.inline(:p) do
+				builder.text("Hello ")
+				builder.inline(:strong) { builder.text("World") }
 			end
 		end
-	end
-	
-	def to_s
-		to_html.to_s
 	end
 end
 ?>

--- a/test/xrb/.template/element.xrb
+++ b/test/xrb/.template/element.xrb
@@ -1,0 +1,19 @@
+<?r
+class MyElement
+	def to_html
+		XRB::Builder.fragment do |builder|
+			builder.inline(:div) do
+				builder.inline(:p) do
+					builder.text("Hello ")
+					builder.inline(:strong) { builder.text("World") }
+				end
+			end
+		end
+	end
+	
+	def to_s
+		to_html.to_s
+	end
+end
+?>
+#{MyElement.new}

--- a/test/xrb/markup.rb
+++ b/test/xrb/markup.rb
@@ -52,23 +52,11 @@ describe XRB::Markup do
 		end
 	end
 	
-	with '.escape_string' do
-		it 'escapes special characters' do
-			expect(XRB::Markup.escape_string("<h1>Hello World</h1>")).to be == "&lt;h1&gt;Hello World&lt;/h1&gt;"
-		end
-		
-		it 'fails to escape non-string' do
-			expect do
-				XRB::Markup.escape_string(Object.new)
-			end.to raise_exception(TypeError)
-		end
-	end
-	
 	with '.append' do
 		it 'appends string to buffer' do
 			buffer = String.new
 			
-			XRB::Markup.append(buffer, "Hello")
+			"Hello".append_markup(buffer)
 			
 			expect(buffer).to be == "Hello"
 		end
@@ -76,7 +64,7 @@ describe XRB::Markup do
 		it 'appends escaped string to buffer' do
 			buffer = String.new
 			
-			XRB::Markup.append(buffer, "<h1>Hello World</h1>")
+			"<h1>Hello World</h1>".append_markup(buffer)
 			
 			expect(buffer).to be == "&lt;h1&gt;Hello World&lt;/h1&gt;"
 		end
@@ -84,7 +72,7 @@ describe XRB::Markup do
 		it 'appends nil to buffer' do
 			buffer = String.new
 			
-			XRB::Markup.append(buffer, nil)
+			nil.append_markup(buffer)
 			
 			expect(buffer).to be == ""
 		end
@@ -92,7 +80,7 @@ describe XRB::Markup do
 		it 'appends MarkupString to buffer' do
 			buffer = String.new
 			
-			XRB::Markup.append(buffer, XRB::MarkupString.raw("<h1>Hello World</h1>"))
+			XRB::MarkupString.raw("<h1>Hello World</h1>").append_markup(buffer)
 			
 			expect(buffer).to be == "<h1>Hello World</h1>"
 		end
@@ -101,14 +89,14 @@ describe XRB::Markup do
 			buffer = Object.new
 			
 			expect do
-				XRB::Markup.append(buffer, "Hello")
+				"Hello".append_markup(buffer)
 			end.to raise_exception(NoMethodError, message: be =~ /<</)
 		end
 		
 		it 'falls back to appending with #<<' do
 			buffer = []
 			
-			XRB::Markup.append(buffer, "<Hello>")
+			"<Hello>".append_markup(buffer)
 			
 			expect(buffer).to be == ["&lt;Hello&gt;"]
 		end

--- a/test/xrb/markup_parser.rb
+++ b/test/xrb/markup_parser.rb
@@ -102,8 +102,8 @@ describe "<foo bar=\"20\" baz>Hello World</foo>" do
 	end
 	
 	it "should track entities" do
-		expect(events[1][2]).to be_a XRB::Markup
-		expect(events[4][1]).to be_a XRB::Markup
+		expect(events[1][2]).to be_a XRB::MarkupString
+		expect(events[4][1]).to be_a XRB::MarkupString
 	end
 end
 
@@ -156,8 +156,8 @@ describe "<p attr=\"foo&amp;bar\">&quot;</p>" do
 	end
 	
 	it "should track entities" do
-		expect(events[1][2]).not.to be_a XRB::Markup
-		expect(events[3][1]).not.to be_a XRB::Markup
+		expect(events[1][2]).not.to be_a XRB::MarkupString
+		expect(events[3][1]).not.to be_a XRB::MarkupString
 	end
 end
 

--- a/test/xrb/markup_string.rb
+++ b/test/xrb/markup_string.rb
@@ -32,7 +32,7 @@ describe XRB::MarkupString do
 	it "should convert nil to empty string" do
 		markup_string = XRB::MarkupString.new
 		
-		XRB::Markup.append(markup_string, nil)
+		nil.append_markup(markup_string)
 		
 		expect(markup_string).to be(:empty?)
 	end


### PR DESCRIPTION
`#{Live::Element.new}` should work, but currently there is no easy conversion or module for indicating that a fragment can be generated.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
